### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/monthly_build.yml
+++ b/.github/workflows/monthly_build.yml
@@ -13,7 +13,7 @@ jobs:
             with:
               ref: master
           - name: Monthly build - latest
-            uses: elgohr/Publish-Docker-Github-Action@master
+            uses: elgohr/Publish-Docker-Github-Action@v5
             with:
               name: monolithprojects/github-action-molecule
               username: monolithprojects

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ jobs:
           - name: Checkout
             uses: actions/checkout@v3
           - name: Publish to Registry
-            uses: elgohr/Publish-Docker-Github-Action@master
+            uses: elgohr/Publish-Docker-Github-Action@v5
             with:
               name: monolithprojects/github-action-molecule
               username: monolithprojects


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore